### PR TITLE
Support a default prelease bump after a production release

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,5 +6,10 @@
     "markdown",
     "latex",
     "plaintext"
+  ],
+  "cSpell.words": [
+    "preminor",
+    "prepatch",
+    "preprepatch"
   ]
 }

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ jobs:
 
 - **default_bump** _(optional)_ - Which type of bump to use when [none is explicitly provided](#bumping) when commiting to a release branch (default: `patch`). You can also set `false` to avoid generating a new tag when none is explicitly provided. Can be `patch, minor or major`.
 - **default_prerelease_bump** _(optional)_ - Which type of bump to use when [none is explicitly provided](#bumping) when commiting to a prerelease branch (default: `prerelease`). You can also set `false` to avoid generating a new tag when none is explicitly provided. Can be `prerelease, prepatch, preminor or premajor`.
-- **initial_prerelease_bump** _(optional)_ - An initial prerelease bump to apply if no prerelease information is present on the latest tag. Defaults to prepatch.
+- **initial_prerelease_bump** _(optional)_ - An initial prerelease bump to apply if no prerelease information is present on the latest tag. Defaults to prepatch. Can be `prepatch, preminor or premajor`.
 - **custom_tag** _(optional)_ - Custom tag name. If specified, it overrides bump settings.
 - **create_annotated_tag** _(optional)_ - Boolean to create an annotated rather than a lightweight one (default: `false`).
 - **tag_prefix** _(optional)_ - A prefix to the tag name (default: `v`).

--- a/README.md
+++ b/README.md
@@ -46,11 +46,11 @@ jobs:
 
 - **default_bump** _(optional)_ - Which type of bump to use when [none is explicitly provided](#bumping) when commiting to a release branch (default: `patch`). You can also set `false` to avoid generating a new tag when none is explicitly provided. Can be `patch, minor or major`.
 - **default_prerelease_bump** _(optional)_ - Which type of bump to use when [none is explicitly provided](#bumping) when commiting to a prerelease branch (default: `prerelease`). You can also set `false` to avoid generating a new tag when none is explicitly provided. Can be `prerelease, prepatch, preminor or premajor`.
+- **initial_prerelease_bump** _(optional)_ - An initial prerelease bump to apply if no prerelease information is present on the latest tag. Defaults to prepatch.
 - **custom_tag** _(optional)_ - Custom tag name. If specified, it overrides bump settings.
 - **create_annotated_tag** _(optional)_ - Boolean to create an annotated rather than a lightweight one (default: `false`).
 - **tag_prefix** _(optional)_ - A prefix to the tag name (default: `v`).
 - **append_to_pre_release_tag** _(optional)_ - A suffix to the pre-release tag name (default: `<branch>`).
-- **initial_prerelease_bump** _(optional)_ - A default prerelease bump to apply if no prerelease information is present on the latest tag. Defaults to prepatch.
 
 #### Customize the conventional commit messages & titles of changelog sections
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ jobs:
 - **create_annotated_tag** _(optional)_ - Boolean to create an annotated rather than a lightweight one (default: `false`).
 - **tag_prefix** _(optional)_ - A prefix to the tag name (default: `v`).
 - **append_to_pre_release_tag** _(optional)_ - A suffix to the pre-release tag name (default: `<branch>`).
+- **initial_prerelease_bump** _(optional)_ - A default prerelease bump to apply if no prerelease information is present on the latest tag. Defaults to prepatch.
 
 #### Customize the conventional commit messages & titles of changelog sections
 

--- a/action.yml
+++ b/action.yml
@@ -59,7 +59,10 @@ inputs:
     description: "Do not perform tagging, just calculate next version and changelog, then exit."
     required: false
     default: "false"
-
+  initial_prerelease_bump: 
+    description: "Default to use if making a prerelease for the first time"
+    default: "prepatch"
+    required: false
 runs:
   using: "node16"
   main: "lib/main.js"

--- a/action.yml
+++ b/action.yml
@@ -24,6 +24,10 @@ inputs:
     description: "Which type of bump to use when none explicitly provided when commiting to a prerelease branch (default: `prerelease`)."
     required: false
     default: "prerelease"
+  initial_prerelease_bump: 
+    description: "An initial prerelease bump to apply if no prerelease information is present on the latest tag. Defaults to prepatch."
+    default: "prepatch"
+    required: false
   tag_prefix:
     description: "A prefix to the tag name (default: `v`)."
     required: false
@@ -59,10 +63,6 @@ inputs:
     description: "Do not perform tagging, just calculate next version and changelog, then exit."
     required: false
     default: "false"
-  initial_prerelease_bump: 
-    description: "A default prerelease bump to apply if no prerelease information is present on the latest tag. Defaults to prepatch."
-    default: "prepatch"
-    required: false
 runs:
   using: "node16"
   main: "lib/main.js"

--- a/action.yml
+++ b/action.yml
@@ -60,7 +60,7 @@ inputs:
     required: false
     default: "false"
   initial_prerelease_bump: 
-    description: "Default to use if making a prerelease for the first time"
+    description: "A default prerelease bump to apply if no prerelease information is present on the latest tag. Defaults to prepatch."
     default: "prepatch"
     required: false
 runs:

--- a/action.yml
+++ b/action.yml
@@ -25,7 +25,7 @@ inputs:
     required: false
     default: "prerelease"
   initial_prerelease_bump: 
-    description: "An initial prerelease bump to apply if no prerelease information is present on the latest tag. Defaults to prepatch."
+    description: "An initial prerelease bump to apply if no prerelease information is present on the latest tag. (default: `prepatch`)."
     default: "prepatch"
     required: false
   tag_prefix:

--- a/action.yml
+++ b/action.yml
@@ -60,7 +60,7 @@ inputs:
     required: false
     default: "false"
   initial_prerelease_bump: 
-    description: "A default prerelease bump to apply if no prerelease information is present on the latest tag. Defaults to prepatch."
+    description: "An initial prerelease bump to apply if no prerelease information is present on the latest tag. Defaults to prepatch."
     default: "prepatch"
     required: false
 runs:

--- a/src/action.ts
+++ b/src/action.ts
@@ -1,5 +1,5 @@
 import * as core from '@actions/core';
-import { gte, inc, parse, ReleaseType, SemVer, valid } from 'semver';
+import { gte, inc, parse, ReleaseType, SemVer, valid, prerelease } from 'semver';
 import { analyzeCommits } from '@semantic-release/commit-analyzer';
 import { generateNotes } from '@semantic-release/release-notes-generator';
 import {
@@ -164,9 +164,20 @@ export default async function main() {
       bump = bump.replace(preReg, '');
     }
 
-    const releaseType: ReleaseType = isPrerelease
+    let releaseType: ReleaseType = isPrerelease
       ? `pre${bump}`
       : bump || defaultBump;
+
+    if (isPrerelease &&
+      defaultPreReleaseBump=="prerelease" &&
+      prerelease(previousTag.name) == null &&
+      defaultBump != "false" &&
+      !customTag &&
+      !customReleaseRules
+    ) {
+      releaseType = defaultBump;
+    }
+
     core.setOutput('release_type', releaseType);
 
     const incrementedVersion = inc(previousVersion, releaseType, identifier);

--- a/src/action.ts
+++ b/src/action.ts
@@ -167,15 +167,11 @@ export default async function main() {
     let releaseType: ReleaseType = isPrerelease
       ? `pre${bump}`
       : bump || defaultBump;
-
-    if (isPrerelease &&
-      defaultPreReleaseBump=="prerelease" &&
-      prerelease(previousTag.name) == null &&
-      defaultBump != "false" &&
-      !customTag &&
-      !customReleaseRules
-    ) {
-      releaseType = defaultBump;
+    const initialPrereleaseBump = core.getInput("initial_prerelease_bump")  as ReleaseType | 'false';
+    if (releaseType == "prerelease"  && initialPrereleaseBump != "false") {
+      if (previousVersion.prerelease.length == 0) {
+        releaseType = initialPrereleaseBump
+      }
     }
 
     core.setOutput('release_type', releaseType);

--- a/src/action.ts
+++ b/src/action.ts
@@ -1,5 +1,13 @@
 import * as core from '@actions/core';
-import { gte, inc, parse, ReleaseType, SemVer, valid, prerelease } from 'semver';
+import {
+  gte,
+  inc,
+  parse,
+  ReleaseType,
+  SemVer,
+  valid,
+  prerelease,
+} from 'semver';
 import { analyzeCommits } from '@semantic-release/commit-analyzer';
 import { generateNotes } from '@semantic-release/release-notes-generator';
 import {
@@ -167,10 +175,12 @@ export default async function main() {
     let releaseType: ReleaseType = isPrerelease
       ? `pre${bump}`
       : bump || defaultBump;
-    const initialPrereleaseBump = core.getInput("initial_prerelease_bump")  as ReleaseType | 'false';
-    if (releaseType == "prerelease"  && initialPrereleaseBump != "false") {
+    const initialPrereleaseBump = core.getInput('initial_prerelease_bump') as
+      | ReleaseType
+      | 'false';
+    if (releaseType == 'prerelease' && initialPrereleaseBump != 'false') {
       if (previousVersion.prerelease.length == 0) {
-        releaseType = initialPrereleaseBump
+        releaseType = initialPrereleaseBump;
       }
     }
 

--- a/tests/action.test.ts
+++ b/tests/action.test.ts
@@ -527,6 +527,45 @@ describe('github-tag-action', () => {
       expect(mockSetFailed).not.toBeCalled();
     });
 
+    it('does handle subsequent prerelease tags', async () => {
+      /*
+       * Given
+       */
+      setInput('default_prerelease_bump', 'prerelease');
+      const commits = [{ message: 'this is my second fix', hash: null }];
+      jest
+        .spyOn(utils, 'getCommits')
+        .mockImplementation(async (sha) => commits);
+
+      const validTags = [
+        {
+          name: 'v1.2.4-prerelease.0',
+          commit: { sha: '012345', url: '' },
+          zipball_url: '',
+          tarball_url: 'string',
+          node_id: 'string',
+        },
+      ];
+      jest
+        .spyOn(utils, 'getValidTags')
+        .mockImplementation(async () => validTags);
+
+      /*
+       * When
+       */
+      await action();
+
+      /*
+       * Then
+       */
+      expect(mockCreateTag).toHaveBeenCalledWith(
+        'v1.2.4-prerelease.1',
+        expect.any(Boolean),
+        expect.any(String)
+      );
+      expect(mockSetFailed).not.toBeCalled();      
+    });
+
     it('does create prepatch tag', async () => {
       /*
        * Given

--- a/tests/action.test.ts
+++ b/tests/action.test.ts
@@ -563,7 +563,7 @@ describe('github-tag-action', () => {
         expect.any(Boolean),
         expect.any(String)
       );
-      expect(mockSetFailed).not.toBeCalled();      
+      expect(mockSetFailed).not.toBeCalled();
     });
 
     it('does create prepatch tag', async () => {

--- a/tests/github_tag_action_use_cases.test.ts
+++ b/tests/github_tag_action_use_cases.test.ts
@@ -48,7 +48,7 @@ describe('develop-versioning-process', () => {
     loadDefaultInputs();
     setInput('default_prerelease_bump', 'prerelease');
     setInput('append_to_pre_release_tag', 'dev');
-    /* Unset this */
+    /* Unset these (loadDefaultInputs doesn't unset items without defaults ) */
     setInput('custom_tag', '');
     setInput('default_bump', '');
   });

--- a/tests/github_tag_action_use_cases.test.ts
+++ b/tests/github_tag_action_use_cases.test.ts
@@ -1,10 +1,3 @@
-/*
-  These tests are intended to run against the github-tag-action code.
-  These are copied over to the github-tag-action repository and run there.
-  They are to demonstrate and prove our specific use case, with a run through our versioning scenario.
-  They are perhaps too specific to our case to belong in the github-tag-action repo, but complement the tests within
-  that repository.
-*/
 import action from '../src/action';
 import * as utils from '../src/utils';
 import * as github from '../src/github';

--- a/tests/github_tag_action_use_cases.test.ts
+++ b/tests/github_tag_action_use_cases.test.ts
@@ -80,6 +80,7 @@ describe('develop-versioning-process', () => {
     /*
      * Given
      */
+    // setInput('initial_prerelease_bump', 'preminor'); // TODO: works too for dev
     setInput("custom_tag", "0.1.0-dev.0");
     const commits = [
       { message: 'Initial commit', hash: null },
@@ -107,7 +108,6 @@ describe('develop-versioning-process', () => {
     await runAndExpectTag('v0.1.0-dev.1', validTags, commits);
   });
 
-  // TODO: Additional prerelease test here - with the v1.0.0 and other tags. - do we get v1.0.0-dev.0, and dev.1 after that.
   it("increments the next prerelease dev tag with v1.0.0 release", async () => {
     /*
       * Given
@@ -115,7 +115,7 @@ describe('develop-versioning-process', () => {
     const commits = [
       { message: 'PE-1234: Merged a PR', hash: null },
     ];
-    setInput('default_bump', 'preminor');
+    setInput('initial_prerelease_bump', 'preminor');
 
     const validTags = [
       {

--- a/tests/github_tag_action_use_cases.test.ts
+++ b/tests/github_tag_action_use_cases.test.ts
@@ -53,13 +53,13 @@ describe('develop-versioning-process', () => {
     setInput('default_bump', '');
   });
 
-  async function runAndExpectTag(tagName: string, validTags: any, commits: any=[]) {
-    jest
-      .spyOn(utils, 'getCommits')
-      .mockImplementation(async (sha) => commits);
-    jest
-      .spyOn(utils, 'getValidTags')
-      .mockImplementation(async () => validTags);
+  async function runAndExpectTag(
+    tagName: string,
+    validTags: any,
+    commits: any = []
+  ) {
+    jest.spyOn(utils, 'getCommits').mockImplementation(async (sha) => commits);
+    jest.spyOn(utils, 'getValidTags').mockImplementation(async () => validTags);
     /*
      * When
      */
@@ -75,26 +75,22 @@ describe('develop-versioning-process', () => {
     expect(mockSetFailed).not.toBeCalled();
   }
 
-  it("creates initial dev tag with custom input", async () => {
+  it('creates initial dev tag with custom input', async () => {
     // This only works if explicit
     /*
      * Given
      */
     // setInput('initial_prerelease_bump', 'preminor'); // TODO: works too for dev
-    setInput("custom_tag", "0.1.0-dev.0");
-    const commits = [
-      { message: 'Initial commit', hash: null },
-    ];
+    setInput('custom_tag', '0.1.0-dev.0');
+    const commits = [{ message: 'Initial commit', hash: null }];
     await runAndExpectTag('v0.1.0-dev.0', []);
   });
 
-  it("increments the next prerelease dev tag", async () => {
+  it('increments the next prerelease dev tag', async () => {
     /*
-      * Given
-      */
-    const commits = [
-      { message: 'PE-1234: Merged a PR', hash: null },
-    ];
+     * Given
+     */
+    const commits = [{ message: 'PE-1234: Merged a PR', hash: null }];
 
     const validTags = [
       {
@@ -108,13 +104,11 @@ describe('develop-versioning-process', () => {
     await runAndExpectTag('v0.1.0-dev.1', validTags, commits);
   });
 
-  it("increments the next prerelease dev tag with v1.0.0 release", async () => {
+  it('increments the next prerelease dev tag with v1.0.0 release', async () => {
     /*
-      * Given
-      */
-    const commits = [
-      { message: 'PE-1234: Merged a PR', hash: null },
-    ];
+     * Given
+     */
+    const commits = [{ message: 'PE-1234: Merged a PR', hash: null }];
     setInput('initial_prerelease_bump', 'preminor');
 
     const validTags = [
@@ -150,12 +144,12 @@ describe('develop-versioning-process', () => {
     await runAndExpectTag('v1.1.0-dev.0', validTags, commits);
   });
 
-  it("creates an rc tag - with version bump", async () => {
+  it('creates an rc tag - with version bump', async () => {
     /*
      * Given
      */
     setInput('append_to_pre_release_tag', 'rc');
-    setInput('default_prerelease_bump', 'minor')
+    setInput('default_prerelease_bump', 'minor');
     /* Commits will be since the last valid rc tag */
     const commits: any[] = [
       { message: 'Dev 0 commit', hash: null },
@@ -188,14 +182,12 @@ describe('develop-versioning-process', () => {
     await runAndExpectTag('v0.2.0-rc.0', validTags, commits);
   });
 
-
-
-  it("creates a dev tag with a minor bump", async () => {
+  it('creates a dev tag with a minor bump', async () => {
     /*
      * Given
      */
     setInput('append_to_pre_release_tag', 'dev');
-    setInput('default_prerelease_bump', 'minor')
+    setInput('default_prerelease_bump', 'minor');
 
     const validTags = [
       {
@@ -216,12 +208,12 @@ describe('develop-versioning-process', () => {
     await runAndExpectTag('v0.2.0-dev.0', validTags, []);
   });
 
-  it("promotes the rc tag to production", async () => {
+  it('promotes the rc tag to production', async () => {
     /*
      * Given
      */
     setBranch('main');
-    setInput("custom_tag", "2.3.0");
+    setInput('custom_tag', '2.3.0');
 
     const validTags = [
       {

--- a/tests/github_tag_action_use_cases.test.ts
+++ b/tests/github_tag_action_use_cases.test.ts
@@ -35,71 +35,6 @@ const mockSetOutput = jest
 
 const mockSetFailed = jest.spyOn(core, 'setFailed');
 
-// describe('semver inc under test conditions', () => {
-//   it("Should increment the prerelease part when given a major version", () => {
-//     const previousVersion = {
-//       options: {},
-//       loose: false,
-//       includePrerelease: false,
-//       raw: "1.0.0",
-//       major: 1,
-//       minor: 0,
-//       patch: 0,
-//       prerelease: [],
-//       build: [],
-//       version: "1.0.0",
-//     };
-//     const releaseType = "prerelease";
-//     const identifier = "dev";
-
-//     const incrementedVersion = sem
-//   });
-//   // It probably shouldn't mutate previousVersion. But that might not matter.
-// });
-describe('utils get-latest-prerelease-tag test conditions', () => {
-  it("Should detect the most recent dev tag", () => {
-    const expectedLatest = {
-        name: 'v1.0.0-dev.0',
-        commit: { sha: '012345', url: '' },
-        zipball_url: '',
-        tarball_url: 'string',
-        node_id: 'string',
-      }
-    const validTags = [
-      {
-        name: 'v1.0.0',
-        commit: { sha: '012345', url: '' },
-        zipball_url: '',
-        tarball_url: 'string',
-        node_id: 'string',
-      },
-      {
-        name: 'v1.0.0-rc.0',
-        commit: { sha: '012345', url: '' },
-        zipball_url: '',
-        tarball_url: 'string',
-        node_id: 'string',
-      },   
-      expectedLatest,
-      {
-        name: 'v0.1.0-dev.0',
-        commit: { sha: '012345', url: '' },
-        zipball_url: '',
-        tarball_url: 'string',
-        node_id: 'string',
-      },
-    ];
-    const identifier = 'dev';
-    const prefixRegex = /^v/;
-    const latestPrereleaseTag = utils.getLatestPrereleaseTag(
-      validTags,
-      identifier,
-      prefixRegex
-    );
-    expect(latestPrereleaseTag).toBe(expectedLatest);
-  });
-});
-
 /* terminology -
     getCommits, mocked as commits, returns commits since the latestTag
     latestPrereleaseTag - this will be the last prereleaseTag that has a matching identifier.
@@ -115,39 +50,13 @@ describe('develop-versioning-process', () => {
     setInput('append_to_pre_release_tag', 'dev');
     /* Unset this */
     setInput('custom_tag', '');
+    setInput('default_bump', '');
   });
 
-  it("does create initial dev tag", async () => {
-    /*
-     * Given
-     */
-    setInput("custom_tag", "0.1.0-dev.0");
-    const commits = [
-      { message: 'Initial commit', hash: null },
-    ];
+  async function runAndExpectTag(tagName: string, validTags: any, commits: any=[]) {
     jest
       .spyOn(utils, 'getCommits')
       .mockImplementation(async (sha) => commits);
-    jest
-      .spyOn(utils, 'getValidTags')
-      .mockImplementation(async () => []);
-    /*
-     * When
-     */
-    await action();
-    /*
-     * Then
-     */
-    expect(mockCreateTag).toHaveBeenCalledWith(
-      /* TODO: How to make this bump to either v0.1.0-dev.0, or v0.0.0-dev.0? Or is this a manual starting tag? */
-      'v0.1.0-dev.0',
-      expect.any(Boolean),
-      expect.any(String)
-    );
-    expect(mockSetFailed).not.toBeCalled();
-  });
-
-  async function runAndExpectTag(tagName: string, validTags: any) {
     jest
       .spyOn(utils, 'getValidTags')
       .mockImplementation(async () => validTags);
@@ -166,17 +75,25 @@ describe('develop-versioning-process', () => {
     expect(mockSetFailed).not.toBeCalled();
   }
 
-  it("does increment the next prerelease dev tag", async () => {
+  it("creates initial dev tag with custom input", async () => {
+    // This only works if explicit
+    /*
+     * Given
+     */
+    setInput("custom_tag", "0.1.0-dev.0");
+    const commits = [
+      { message: 'Initial commit', hash: null },
+    ];
+    await runAndExpectTag('v0.1.0-dev.0', []);
+  });
+
+  it("increments the next prerelease dev tag", async () => {
     /*
       * Given
       */
     const commits = [
       { message: 'PE-1234: Merged a PR', hash: null },
     ];
-    jest
-      .spyOn(utils, 'getCommits')
-      .mockImplementation(async (sha) => commits);
-
 
     const validTags = [
       {
@@ -187,21 +104,18 @@ describe('develop-versioning-process', () => {
         node_id: 'string',
       },
     ];
-    await runAndExpectTag('v0.1.0-dev.1', validTags);
+    await runAndExpectTag('v0.1.0-dev.1', validTags, commits);
   });
 
   // TODO: Additional prerelease test here - with the v1.0.0 and other tags. - do we get v1.0.0-dev.0, and dev.1 after that.
-  it("does increment the next prerelease dev tag with v1.0.0 release", async () => {
+  it("increments the next prerelease dev tag with v1.0.0 release", async () => {
     /*
       * Given
       */
     const commits = [
       { message: 'PE-1234: Merged a PR', hash: null },
     ];
-    jest
-      .spyOn(utils, 'getCommits')
-      .mockImplementation(async (sha) => commits);
-
+    setInput('default_bump', 'preminor');
 
     const validTags = [
       {
@@ -233,10 +147,10 @@ describe('develop-versioning-process', () => {
         node_id: 'string',
       },
     ];
-    await runAndExpectTag('v1.0.0-dev.1', validTags);
+    await runAndExpectTag('v1.1.0-dev.0', validTags, commits);
   });
 
-  it("does create an rc tag - with version bump", async () => {
+  it("creates an rc tag - with version bump", async () => {
     /*
      * Given
      */
@@ -247,10 +161,6 @@ describe('develop-versioning-process', () => {
       { message: 'Dev 0 commit', hash: null },
       { message: 'Dev 1 commit', hash: null },
     ];
-    jest
-      .spyOn(utils, 'getCommits')
-      .mockImplementation(async (sha) => commits);
-
 
     const validTags = [
       {
@@ -275,22 +185,17 @@ describe('develop-versioning-process', () => {
         node_id: 'string',
       },
     ];
-    await runAndExpectTag('v0.2.0-rc.0', validTags);
+    await runAndExpectTag('v0.2.0-rc.0', validTags, commits);
   });
 
 
 
-  it("does create a dev tag with a minor bump", async () => {
+  it("creates a dev tag with a minor bump", async () => {
     /*
      * Given
      */
     setInput('append_to_pre_release_tag', 'dev');
     setInput('default_prerelease_bump', 'minor')
-    /* No commits - we are retagging */
-    const commits: any[] = [];
-    jest
-      .spyOn(utils, 'getCommits')
-      .mockImplementation(async (sha) => commits);
 
     const validTags = [
       {
@@ -308,20 +213,15 @@ describe('develop-versioning-process', () => {
         node_id: 'string',
       },
     ];
-    await runAndExpectTag('v0.2.0-dev.0', validTags);
+    await runAndExpectTag('v0.2.0-dev.0', validTags, []);
   });
 
-  it("does promote the rc tag to production", async () => {
+  it("promotes the rc tag to production", async () => {
     /*
      * Given
      */
     setBranch('main');
     setInput("custom_tag", "2.3.0");
-    /* Commits will be everything since the last release to main */
-    const commits: any[] = [];
-    jest
-      .spyOn(utils, 'getCommits')
-      .mockImplementation(async (sha) => commits);
 
     const validTags = [
       {
@@ -353,21 +253,6 @@ describe('develop-versioning-process', () => {
         node_id: 'string',
       },
     ];
-    jest
-      .spyOn(utils, 'getValidTags')
-      .mockImplementation(async () => validTags);
-    /*
-     * When
-     */
-    await action();
-    /*
-     * Then
-     */
-    expect(mockCreateTag).toHaveBeenCalledWith(
-      'v2.3.0',
-      expect.any(Boolean),
-      expect.any(String)
-    );
-    expect(mockSetFailed).not.toBeCalled();
+    await runAndExpectTag('v2.3.0', validTags, []);
   });
 });

--- a/tests/github_tag_action_use_cases.test.ts
+++ b/tests/github_tag_action_use_cases.test.ts
@@ -1,0 +1,373 @@
+/*
+  These tests are intended to run against the github-tag-action code.
+  These are copied over to the github-tag-action repository and run there.
+  They are to demonstrate and prove our specific use case, with a run through our versioning scenario.
+  They are perhaps too specific to our case to belong in the github-tag-action repo, but complement the tests within
+  that repository.
+*/
+import action from '../src/action';
+import * as utils from '../src/utils';
+import * as github from '../src/github';
+import * as core from '@actions/core';
+import {
+  loadDefaultInputs,
+  setBranch,
+  setCommitSha,
+  setInput,
+  setRepository,
+} from './helper.test';
+
+jest.spyOn(core, 'debug').mockImplementation(() => {});
+jest.spyOn(core, 'info').mockImplementation(() => {});
+jest.spyOn(console, 'info').mockImplementation(() => {});
+
+beforeAll(() => {
+  setRepository('https://github.com', 'org/repo');
+});
+
+const mockCreateTag = jest
+  .spyOn(github, 'createTag')
+  .mockResolvedValue(undefined);
+
+const mockSetOutput = jest
+  .spyOn(core, 'setOutput')
+  .mockImplementation(() => {});
+
+const mockSetFailed = jest.spyOn(core, 'setFailed');
+
+// describe('semver inc under test conditions', () => {
+//   it("Should increment the prerelease part when given a major version", () => {
+//     const previousVersion = {
+//       options: {},
+//       loose: false,
+//       includePrerelease: false,
+//       raw: "1.0.0",
+//       major: 1,
+//       minor: 0,
+//       patch: 0,
+//       prerelease: [],
+//       build: [],
+//       version: "1.0.0",
+//     };
+//     const releaseType = "prerelease";
+//     const identifier = "dev";
+
+//     const incrementedVersion = sem
+//   });
+//   // It probably shouldn't mutate previousVersion. But that might not matter.
+// });
+describe('utils get-latest-prerelease-tag test conditions', () => {
+  it("Should detect the most recent dev tag", () => {
+    const expectedLatest = {
+        name: 'v1.0.0-dev.0',
+        commit: { sha: '012345', url: '' },
+        zipball_url: '',
+        tarball_url: 'string',
+        node_id: 'string',
+      }
+    const validTags = [
+      {
+        name: 'v1.0.0',
+        commit: { sha: '012345', url: '' },
+        zipball_url: '',
+        tarball_url: 'string',
+        node_id: 'string',
+      },
+      {
+        name: 'v1.0.0-rc.0',
+        commit: { sha: '012345', url: '' },
+        zipball_url: '',
+        tarball_url: 'string',
+        node_id: 'string',
+      },   
+      expectedLatest,
+      {
+        name: 'v0.1.0-dev.0',
+        commit: { sha: '012345', url: '' },
+        zipball_url: '',
+        tarball_url: 'string',
+        node_id: 'string',
+      },
+    ];
+    const identifier = 'dev';
+    const prefixRegex = /^v/;
+    const latestPrereleaseTag = utils.getLatestPrereleaseTag(
+      validTags,
+      identifier,
+      prefixRegex
+    );
+    expect(latestPrereleaseTag).toBe(expectedLatest);
+  });
+});
+
+/* terminology -
+    getCommits, mocked as commits, returns commits since the latestTag
+    latestPrereleaseTag - this will be the last prereleaseTag that has a matching identifier.
+      so will only be the `-rc.n` series for an `-rc` identifier.
+ */
+describe('develop-versioning-process', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setBranch('develop');
+    setCommitSha('79e0ea271c26aa152beef77c3275ff7b8f8d8274');
+    loadDefaultInputs();
+    setInput('default_prerelease_bump', 'prerelease');
+    setInput('append_to_pre_release_tag', 'dev');
+    /* Unset this */
+    setInput('custom_tag', '');
+  });
+
+  it("does create initial dev tag", async () => {
+    /*
+     * Given
+     */
+    setInput("custom_tag", "0.1.0-dev.0");
+    const commits = [
+      { message: 'Initial commit', hash: null },
+    ];
+    jest
+      .spyOn(utils, 'getCommits')
+      .mockImplementation(async (sha) => commits);
+    jest
+      .spyOn(utils, 'getValidTags')
+      .mockImplementation(async () => []);
+    /*
+     * When
+     */
+    await action();
+    /*
+     * Then
+     */
+    expect(mockCreateTag).toHaveBeenCalledWith(
+      /* TODO: How to make this bump to either v0.1.0-dev.0, or v0.0.0-dev.0? Or is this a manual starting tag? */
+      'v0.1.0-dev.0',
+      expect.any(Boolean),
+      expect.any(String)
+    );
+    expect(mockSetFailed).not.toBeCalled();
+  });
+
+  async function runAndExpectTag(tagName: string, validTags: any) {
+    jest
+      .spyOn(utils, 'getValidTags')
+      .mockImplementation(async () => validTags);
+    /*
+     * When
+     */
+    await action();
+    /*
+     * Then
+     */
+    expect(mockCreateTag).toHaveBeenCalledWith(
+      tagName,
+      expect.any(Boolean),
+      expect.any(String)
+    );
+    expect(mockSetFailed).not.toBeCalled();
+  }
+
+  it("does increment the next prerelease dev tag", async () => {
+    /*
+      * Given
+      */
+    const commits = [
+      { message: 'PE-1234: Merged a PR', hash: null },
+    ];
+    jest
+      .spyOn(utils, 'getCommits')
+      .mockImplementation(async (sha) => commits);
+
+
+    const validTags = [
+      {
+        name: 'v0.1.0-dev.0',
+        commit: { sha: '012345', url: '' },
+        zipball_url: '',
+        tarball_url: 'string',
+        node_id: 'string',
+      },
+    ];
+    await runAndExpectTag('v0.1.0-dev.1', validTags);
+  });
+
+  // TODO: Additional prerelease test here - with the v1.0.0 and other tags. - do we get v1.0.0-dev.0, and dev.1 after that.
+  it("does increment the next prerelease dev tag with v1.0.0 release", async () => {
+    /*
+      * Given
+      */
+    const commits = [
+      { message: 'PE-1234: Merged a PR', hash: null },
+    ];
+    jest
+      .spyOn(utils, 'getCommits')
+      .mockImplementation(async (sha) => commits);
+
+
+    const validTags = [
+      {
+        name: 'v1.0.0',
+        commit: { sha: '012345', url: '' },
+        zipball_url: '',
+        tarball_url: 'string',
+        node_id: 'string',
+      },
+      {
+        name: 'v1.0.0-rc.0',
+        commit: { sha: '012345', url: '' },
+        zipball_url: '',
+        tarball_url: 'string',
+        node_id: 'string',
+      },
+      {
+        name: 'v1.0.0-dev.0',
+        commit: { sha: '012345', url: '' },
+        zipball_url: '',
+        tarball_url: 'string',
+        node_id: 'string',
+      },
+      {
+        name: 'v0.1.0-dev.0',
+        commit: { sha: '012345', url: '' },
+        zipball_url: '',
+        tarball_url: 'string',
+        node_id: 'string',
+      },
+    ];
+    await runAndExpectTag('v1.0.0-dev.1', validTags);
+  });
+
+  it("does create an rc tag - with version bump", async () => {
+    /*
+     * Given
+     */
+    setInput('append_to_pre_release_tag', 'rc');
+    setInput('default_prerelease_bump', 'minor')
+    /* Commits will be since the last valid rc tag */
+    const commits: any[] = [
+      { message: 'Dev 0 commit', hash: null },
+      { message: 'Dev 1 commit', hash: null },
+    ];
+    jest
+      .spyOn(utils, 'getCommits')
+      .mockImplementation(async (sha) => commits);
+
+
+    const validTags = [
+      {
+        name: 'v0.1.0-rc.0',
+        commit: { sha: '012345', url: '' },
+        zipball_url: '',
+        tarball_url: 'string',
+        node_id: 'string',
+      },
+      {
+        name: 'v0.1.0-dev.0',
+        commit: { sha: '012345', url: '' },
+        zipball_url: '',
+        tarball_url: 'string',
+        node_id: 'string',
+      },
+      {
+        name: 'v0.1.0-dev.1',
+        commit: { sha: '012749', url: '' },
+        zipball_url: '',
+        tarball_url: 'string',
+        node_id: 'string',
+      },
+    ];
+    await runAndExpectTag('v0.2.0-rc.0', validTags);
+  });
+
+
+
+  it("does create a dev tag with a minor bump", async () => {
+    /*
+     * Given
+     */
+    setInput('append_to_pre_release_tag', 'dev');
+    setInput('default_prerelease_bump', 'minor')
+    /* No commits - we are retagging */
+    const commits: any[] = [];
+    jest
+      .spyOn(utils, 'getCommits')
+      .mockImplementation(async (sha) => commits);
+
+    const validTags = [
+      {
+        name: 'v0.1.0-dev.1',
+        commit: { sha: '012357', url: '' },
+        zipball_url: '',
+        tarball_url: 'string',
+        node_id: 'string',
+      },
+      {
+        name: 'v0.2.0-rc.0',
+        commit: { sha: '012357', url: '' },
+        zipball_url: '',
+        tarball_url: 'string',
+        node_id: 'string',
+      },
+    ];
+    await runAndExpectTag('v0.2.0-dev.0', validTags);
+  });
+
+  it("does promote the rc tag to production", async () => {
+    /*
+     * Given
+     */
+    setBranch('main');
+    setInput("custom_tag", "2.3.0");
+    /* Commits will be everything since the last release to main */
+    const commits: any[] = [];
+    jest
+      .spyOn(utils, 'getCommits')
+      .mockImplementation(async (sha) => commits);
+
+    const validTags = [
+      {
+        name: 'v2.2.0',
+        commit: { sha: '012357', url: '' },
+        zipball_url: '',
+        tarball_url: 'string',
+        node_id: 'string',
+      },
+      {
+        name: 'v2.2.0-dev.0',
+        commit: { sha: '012360', url: '' },
+        zipball_url: '',
+        tarball_url: 'string',
+        node_id: 'string',
+      },
+      {
+        name: 'v2.3.0-rc.0',
+        commit: { sha: '012360', url: '' },
+        zipball_url: '',
+        tarball_url: 'string',
+        node_id: 'string',
+      },
+      {
+        name: 'v2.3.0-dev.0',
+        commit: { sha: '012360', url: '' },
+        zipball_url: '',
+        tarball_url: 'string',
+        node_id: 'string',
+      },
+    ];
+    jest
+      .spyOn(utils, 'getValidTags')
+      .mockImplementation(async () => validTags);
+    /*
+     * When
+     */
+    await action();
+    /*
+     * Then
+     */
+    expect(mockCreateTag).toHaveBeenCalledWith(
+      'v2.3.0',
+      expect.any(Boolean),
+      expect.any(String)
+    );
+    expect(mockSetFailed).not.toBeCalled();
+  });
+});

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -184,6 +184,50 @@ describe('utils', () => {
     });
   });
 
+  describe('method: getLatestPrereleaseTag', () => {
+    it("Should detect the most recent dev tag", () => {
+      const expectedLatest = {
+          name: 'v1.0.0-dev.0',
+          commit: { sha: '012345', url: '' },
+          zipball_url: '',
+          tarball_url: 'string',
+          node_id: 'string',
+        }
+      const validTags = [
+        {
+          name: 'v1.0.0',
+          commit: { sha: '012345', url: '' },
+          zipball_url: '',
+          tarball_url: 'string',
+          node_id: 'string',
+        },
+        {
+          name: 'v1.0.0-rc.0',
+          commit: { sha: '012345', url: '' },
+          zipball_url: '',
+          tarball_url: 'string',
+          node_id: 'string',
+        },   
+        expectedLatest,
+        {
+          name: 'v0.1.0-dev.0',
+          commit: { sha: '012345', url: '' },
+          zipball_url: '',
+          tarball_url: 'string',
+          node_id: 'string',
+        },
+      ];
+      const identifier = 'dev';
+      const prefixRegex = /^v/;
+      const latestPrereleaseTag = utils.getLatestPrereleaseTag(
+        validTags,
+        identifier,
+        prefixRegex
+      );
+      expect(latestPrereleaseTag).toBe(expectedLatest);
+    });
+  });
+
   describe('custom release types', () => {
     it('maps custom release types', () => {
       /*

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -185,14 +185,14 @@ describe('utils', () => {
   });
 
   describe('method: getLatestPrereleaseTag', () => {
-    it("Should detect the most recent dev tag", () => {
+    it('Should detect the most recent dev tag', () => {
       const expectedLatest = {
-          name: 'v1.0.0-dev.0',
-          commit: { sha: '012345', url: '' },
-          zipball_url: '',
-          tarball_url: 'string',
-          node_id: 'string',
-        }
+        name: 'v1.0.0-dev.0',
+        commit: { sha: '012345', url: '' },
+        zipball_url: '',
+        tarball_url: 'string',
+        node_id: 'string',
+      };
       const validTags = [
         {
           name: 'v1.0.0',
@@ -207,7 +207,7 @@ describe('utils', () => {
           zipball_url: '',
           tarball_url: 'string',
           node_id: 'string',
-        },   
+        },
         expectedLatest,
         {
           name: 'v0.1.0-dev.0',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,8 +5,7 @@
     "outDir": "./lib",                        /* Redirect output structure to the directory. */
     "rootDir": "./src",
     "strict": true,
-    "esModuleInterop": true,
-    "sourceMap": true    
+    "esModuleInterop": true
   },
   "exclude": ["node_modules", "**/*.test.ts"]
 }


### PR DESCRIPTION
If a full production release (v1.0.0) has been made, then this will allow the next release type for the next tag on a prerelease branch  to be overridden.
The default (and only option) before was prepatch.
The new input option initial_prerelease_bump will allow a bump type to override this.

It will apply when the latest tag does not have prerelease information. This will mean production release tags, or when no previous tag has been found.